### PR TITLE
Add multiple bridge launcher

### DIFF
--- a/config/multiple_ros_ign_bridge.yaml
+++ b/config/multiple_ros_ign_bridge.yaml
@@ -5,18 +5,40 @@ multiple_ignition_bridge:
     ign_frame_id: ${robot}/upper_imu_link/upper_imu
     ros_frame_id: upper_imu_link
     ign_topic: /world/${world}/model/${robot}/link/base_link/sensor/upper_imu/imu
-    ros_topic: /upper_imu/data_raw
-    convert_args: &imu_convert sensor_msgs/msg/Imu[ignition.msgs.IMU
+    ros_topic: upper_imu/data_raw
+    convert_args: sensor_msgs/msg/Imu[ignition.msgs.IMU
   lower_imu_bridge:
     type: bridge
     with_stf: !!str true
     ign_frame_id: ${robot}/lower_imu_link/upper_imu
     ros_frame_id: lower_imu_link
     ign_topic: /world/${world}/model/${robot}/link/base_link/sensor/lower_imu/imu
-    ros_topic: /lower_imu/data_raw
+    ros_topic: lower_imu/data_raw
     convert_args: sensor_msgs/msg/Imu[ignition.msgs.IMU
-  #front_camera_bridge:
-  #  type: image_bridge
-  #joint_states_bridge:
-  #  type: bridge
-  #  namespace: &simulator_namespace /simulator
+  front_camera_info_bridge:
+    type: bridge
+    with_stf: !!str true
+    ign_frame_id: ${robot}/upper_body_link/front_camera
+    ros_frame_id: front_camera_link
+    ign_topic: /world/${world}/model/test_robot/link/upper_body_link/sensor/front_camera/camera_info
+    ros_topic: front_camera/camera_info
+    convert_args: sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo
+  front_camera_bridge:
+    type: image_bridge
+    ign_topic: /world/${world}/model/test_robot/link/upper_body_link/sensor/front_camera/image
+    ros_topic: front_camera/image
+  front_depth_camera_bridge:
+    type: image_bridge
+    ign_topic: /world/${world}/model/test_robot/link/upper_body_link/sensor/front_camera/depth_image
+    ros_topic: front_camera/depth_image
+  front_depth_camera_points_bridge:
+    type: bridge
+    ign_topic: /world/${world}/model/test_robot/link/upper_body_link/sensor/front_camera/points
+    ros_topic: front_camera/points
+    convert_args: sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked
+  joint_states_bridge:
+    type: bridge
+    namespace: /simulator
+    ign_topic: /world/${world}/model/${robot}/joint_state
+    ros_topic: joint_states
+    convert_args: sensor_msgs/msg/JointState[ignition.msgs.Model

--- a/config/multiple_ros_ign_bridge.yaml
+++ b/config/multiple_ros_ign_bridge.yaml
@@ -10,7 +10,7 @@ multiple_ignition_bridge:
   lower_imu_bridge:
     type: bridge
     with_stf: !!str true
-    ign_frame_id: ${robot}/lower_imu_link/upper_imu
+    ign_frame_id: ${robot}/base_link/lower_imu
     ros_frame_id: lower_imu_link
     ign_topic: /world/${world}/model/${robot}/link/base_link/sensor/lower_imu/imu
     ros_topic: lower_imu/data_raw

--- a/config/multiple_ros_ign_bridge.yaml
+++ b/config/multiple_ros_ign_bridge.yaml
@@ -1,0 +1,22 @@
+multiple_ignition_bridge:
+  upper_imu_bridge:
+    type: bridge
+    with_stf: !!str true
+    ign_frame_id: ${robot}/upper_imu_link/upper_imu
+    ros_frame_id: upper_imu_link
+    ign_topic: /world/${world}/model/${robot}/link/base_link/sensor/upper_imu/imu
+    ros_topic: /upper_imu/data_raw
+    convert_args: &imu_convert sensor_msgs/msg/Imu[ignition.msgs.IMU
+  lower_imu_bridge:
+    type: bridge
+    with_stf: !!str true
+    ign_frame_id: ${robot}/lower_imu_link/upper_imu
+    ros_frame_id: lower_imu_link
+    ign_topic: /world/${world}/model/${robot}/link/base_link/sensor/lower_imu/imu
+    ros_topic: /lower_imu/data_raw
+    convert_args: sensor_msgs/msg/Imu[ignition.msgs.IMU
+  #front_camera_bridge:
+  #  type: image_bridge
+  #joint_states_bridge:
+  #  type: bridge
+  #  namespace: &simulator_namespace /simulator

--- a/launch/ignition_bridge.launch.py
+++ b/launch/ignition_bridge.launch.py
@@ -62,7 +62,7 @@ def generate_declare_launch_arguments():
         ),
         DeclareLaunchArgument(
             'stf_node_name',
-            default_value = 'stf',
+            default_value = AnonName('stf'),
             description = 'Static transform publisher node name (string)'
         )
     ]
@@ -104,10 +104,7 @@ def generate_launch_nodes():
             Node(
                 package = 'tf2_ros',
                 executable = 'static_transform_publisher',
-                # TODO
-                name = AnonName(
-                    LaunchConfiguration('stf_node_name')
-                ),
+                name = LaunchConfiguration('stf_node_name'),
                 output = output,
                 parameters = [
                     {'use_sim_time': True}

--- a/launch/multiple_ignition_bridge.launch.py
+++ b/launch/multiple_ignition_bridge.launch.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env -S python3
+
+import os
+import sys
+import yaml
+import string
+import re
+
+from typing import NamedTuple
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import (
+    LaunchDescription,
+    LaunchContext
+)
+from launch.actions import (
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+    GroupAction,
+    EmitEvent,
+    LogInfo
+)
+from launch.conditions import (
+    IfCondition
+)
+from launch.substitutions import (
+    LaunchConfiguration,
+    TextSubstitution,
+    ThisLaunchFileDir,
+    AnonName
+)
+from launch.launch_description_sources import AnyLaunchDescriptionSource
+from launch.events import Shutdown
+from launch_ros.actions import (
+    Node,
+    PushRosNamespace
+)
+
+
+class MultipleIgnBridgeConfigParser(object):
+    def __init__(self):
+        self.config_namespace = 'multiple_ignition_bridge'
+        self.bridge_configs = {}
+        self.robot_name = ''
+        self.world_name = ''
+
+    def open(self, filename):
+        with open(filename, 'r') as file:
+            yaml_loader = yaml.SafeLoader
+
+            def string_constructor(loader, node):
+                context = {
+                    'robot': self.robot_name,
+                    'world': self.world_name
+                }
+                template = string.Template(node.value)
+                return template.substitute(context)
+
+            string_resolver = 'tag:yaml.org.2002:str'
+
+            yaml_loader.add_constructor(
+                string_resolver,
+                string_constructor
+            )
+            yaml_loader.add_implicit_resolver(
+                string_resolver,
+                re.compile(r'(.*)\$\{(.*)\}'),
+                None
+            )
+            yaml_config = yaml.load(
+                file,
+                Loader = yaml_loader
+            )
+
+            if yaml_config.get(self.config_namespace) == None:
+                print('Not found bridge configuration namespace')
+                sys.exit(1)
+
+            self.bridge_configs = yaml_config[self.config_namespace]
+
+    def get_node_names(self):
+        return self.bridge_configs.values()
+
+    def get_bridge_type(self, node_name):
+        type = self.bridge_configs[node_name].get('type')
+
+        assert type != None
+
+        return type
+
+    def get_bridge_namespace(self, node_name):
+        namespace = self.bridge_configs[node_name].get('namespace')
+
+        if namespace == None:
+            namespace = ''
+
+        return namespace
+
+    def get_launch_arguments(self, node_name):
+        launch_arguments = self._arguments_filter(node_name)
+        return launch_arguments.items()
+
+    def set_robot_name(self, name):
+        self.robot_name = name
+
+    def set_world_name(self, name):
+        self.world_name = name
+
+    def _arguments_filter(self, node_name):
+        config = self.bridge_configs[node_name]
+
+        # Default launch arguments
+        with_stf = ''
+        ign_frame_id = ''
+        ros_frame_id = ''
+        ign_topic = ''
+        ros_topic = ''
+        convert_args = ''
+
+        with_stf = config.get('with_stf')
+        ign_frame_id = config.get('ign_frame_id')
+        ros_frame_id = config.get('ros_frame_id')
+        ign_topic = config.get('ign_topic')
+        ros_topic = config.get('ros_topic')
+        convert_args = config.get('convert_args')
+
+        assert with_stf and ign_frame_id
+        assert with_stf and ros_frame_id
+        assert convert_args
+        assert ign_topic or ros_topic
+
+        return {
+            'with_stf': with_stf,
+            'ign_frame_id': ign_frame_id,
+            'ros_frame_id': ros_frame_id,
+            'ign_topic': ign_topic,
+            'ros_topic': ros_topic,
+            'convert_args': convert_args,
+            'bridge_node_name': node_name,
+            'stf_node_name': node_name + '_stf'
+        }
+
+def generate_launch_description():
+    config_namespace = 'multiple_ignition_bridge'
+
+    launch_description = LaunchDescription(
+        generate_declare_launch_arguments()
+    )
+
+    def load_launch_arguments(
+        context: LaunchContext,
+        config_file,
+        robot_name,
+        world_name):
+
+        config_file_str = context.perform_substitution(config_file)
+        robot_name_str = context.perform_substitution(robot_name)
+        world_name_str = context.perform_substitution(world_name)
+
+        config_parser = MultipleIgnBridgeConfigParser()
+
+        config_parser.set_robot_name(robot_name_str)
+        config_parser.set_world_name(world_name_str)
+        config_parser.open(config_file_str)
+
+        bridge_launch = {
+            'bridge':
+                [ThisLaunchFileDir(), '/ignition_bridge.launch.py'],
+            'image_bridge':
+                [ThisLaunchFileDir(), '/ignition_image_bridge.launch.py']
+        }
+
+        for bridge_node_name in config_parser.bridge_configs:
+            launch_file = bridge_launch[
+                config_parser.get_bridge_type(
+                    bridge_node_name
+                )
+            ]
+
+            launch_description.add_action(GroupAction(actions = [
+                    PushRosNamespace(
+                        namespace = config_parser.get_bridge_namespace(
+                            bridge_node_name
+                        )
+                    ),
+                    IncludeLaunchDescription(
+                        AnyLaunchDescriptionSource(
+                            launch_file
+                        ),
+                        launch_arguments = config_parser.get_launch_arguments(
+                            bridge_node_name
+                        )
+                    )
+                ])
+            )
+
+
+    launch_description.add_action(
+        GroupAction(actions = [
+            OpaqueFunction(
+                function = load_launch_arguments,
+                args = [
+                    LaunchConfiguration('multiple_bridge_config'),
+                    LaunchConfiguration('robot_name'),
+                    LaunchConfiguration('world_name')
+                ]
+            )
+        ])
+    )
+
+    return launch_description
+
+
+def generate_declare_launch_arguments():
+    this_pkg_share_dir = get_package_share_directory('ros_ign_utils')
+
+    return [
+        DeclareLaunchArgument(
+            'multiple_bridge_config',
+            default_value = [
+                os.path.join(
+                    this_pkg_share_dir,
+                    'config',
+                    'multiple_ros_ign_bridge.yaml'
+                )
+            ],
+            description = 'Multiple ros_ign bridge configulation file path (string)'
+        ),
+        DeclareLaunchArgument(
+            'world_name',
+            default_value = ['checker_ground_plane'],
+            description = 'Simulation world name of ignition gazebo (string)'
+        ),
+        DeclareLaunchArgument(
+            'robot_name',
+            default_value = ['test_robot'],
+            description = 'Simulate robot model name (string)'
+        ),
+    ]
+
+if __name__ == '__main__':
+    launch_service = LaunchService()
+    launch_service.include_launch_description(generate_launch_description())
+    launch_service.run()
+

--- a/launch/simulate_test_robot.launch.py
+++ b/launch/simulate_test_robot.launch.py
@@ -93,118 +93,123 @@ def generate_launch_nodes():
                 'robot_model_file': LaunchConfiguration('robot_model_file')
             }.items()
         ),
-        GroupAction(actions = [
-            PushRosNamespace(
-                namespace = namespace
-            ),
-            IncludeLaunchDescription(
-                AnyLaunchDescriptionSource([
-                    ThisLaunchFileDir(), '/ignition_bridge.launch.py'
-                ]),
-                launch_arguments = {
-                    'with_stf': 'false',
-                    'ign_topic': ['/world/', world_name, '/model/test_robot/joint_state'],
-                    'ros_topic': 'joint_states',
-                    'convert_args': 'sensor_msgs/msg/JointState[ignition.msgs.Model',
-                    'bridge_node_name': 'test_robot_joint_state_bridge'
-                }.items()
-            )
-        ]),
-        GroupAction(actions = [
-            IncludeLaunchDescription(
-                AnyLaunchDescriptionSource([
-                    ThisLaunchFileDir(), '/test_robot.launch.py'
-                ]),
-                launch_arguments = {
-                    # Launch arguments chain guard
-                    'namespace': '',
-                    'use_sim_time': use_sim_time,
-                    'use_rviz': LaunchConfiguration('use_rviz')
-                }.items()
-            ),
-            IncludeLaunchDescription(
-                AnyLaunchDescriptionSource([
-                    ThisLaunchFileDir(), '/ignition_bridge.launch.py'
-                ]),
-                launch_arguments = {
-                    'with_stf': 'true',
-                    'ign_frame_id': ['test_robot/upper_body_link/upper_imu'],
-                    'ros_frame_id': 'upper_imu_link',
-                    'ign_topic': [
-                        '/world/', world_name, '/model/test_robot/link/upper_body_link/sensor/upper_imu/imu'
-                    ],
-                    'ros_topic': 'upper_imu/data_raw',
-                    'convert_args': 'sensor_msgs/msg/Imu[ignition.msgs.IMU',
-                }.items()
-            ),
-            IncludeLaunchDescription(
-                AnyLaunchDescriptionSource([
-                    ThisLaunchFileDir(), '/ignition_bridge.launch.py'
-                ]),
-                launch_arguments = {
-                    'with_stf': 'true',
-                    'ign_frame_id': ['test_robot/base_link/lower_imu'],
-                    'ros_frame_id': 'lower_imu_link',
-                    'ign_topic': [
-                        '/world/', world_name, '/model/test_robot/link/base_link/sensor/lower_imu/imu'
-                    ],
-                    'ros_topic': 'lower_imu/data_raw',
-                    'convert_args': 'sensor_msgs/msg/Imu[ignition.msgs.IMU',
-                }.items()
-            ),
-            IncludeLaunchDescription(
-                AnyLaunchDescriptionSource([
-                    ThisLaunchFileDir(), '/ignition_bridge.launch.py'
-                ]),
-                launch_arguments = {
-                    'with_stf': 'true',
-                    'ign_frame_id': ['test_robot/upper_body_link/front_camera'],
-                    'ros_frame_id': 'front_camera_link',
-                    'ign_topic': [
-                        '/world/', world_name, '/model/test_robot/link/upper_body_link/sensor/front_camera/camera_info'
-                    ],
-                    'ros_topic': 'front_camera/camera_info',
-                    'convert_args': 'sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo'
-                }.items()
-            ),
-            IncludeLaunchDescription(
-                AnyLaunchDescriptionSource([
-                    ThisLaunchFileDir(), '/ignition_image_bridge.launch.py'
-                ]),
-                launch_arguments = {
-                    'with_stf': 'false',
-                    'ign_topic': [
-                        '/world/', world_name, '/model/test_robot/link/upper_body_link/sensor/front_camera/image'
-                    ],
-                    'ros_topic': 'front_camera/image'
-                }.items()
-            ),
-            IncludeLaunchDescription(
-                AnyLaunchDescriptionSource([
-                    ThisLaunchFileDir(), '/ignition_image_bridge.launch.py'
-                ]),
-                launch_arguments = {
-                    'with_stf': 'false',
-                    'ign_topic': [
-                        '/world/', world_name, '/model/test_robot/link/upper_body_link/sensor/front_camera/depth_image'
-                    ],
-                    'ros_topic': 'front_camera/depth_image'
-                }.items()
-            ),
-            IncludeLaunchDescription(
-                AnyLaunchDescriptionSource([
-                    ThisLaunchFileDir(), '/ignition_bridge.launch.py'
-                ]),
-                launch_arguments = {
-                    'with_stf': 'false',
-                    'ign_topic': [
-                        '/world/', world_name, '/model/test_robot/link/upper_body_link/sensor/front_camera/points'
-                    ],
-                    'ros_topic': 'front_camera/points',
-                    'convert_args': 'sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked'
-                }.items()
-            )
-        ])
+        IncludeLaunchDescription(
+            AnyLaunchDescriptionSource([
+                ThisLaunchFileDir(), '/multiple_ignition_bridge.launch.py'
+            ]),
+        )
+        #GroupAction(actions = [
+        #    PushRosNamespace(
+        #        namespace = namespace
+        #    ),
+        #    IncludeLaunchDescription(
+        #        AnyLaunchDescriptionSource([
+        #            ThisLaunchFileDir(), '/ignition_bridge.launch.py'
+        #        ]),
+        #        launch_arguments = {
+        #            'with_stf': 'false',
+        #            'ign_topic': ['/world/', world_name, '/model/test_robot/joint_state'],
+        #            'ros_topic': 'joint_states',
+        #            'convert_args': 'sensor_msgs/msg/JointState[ignition.msgs.Model',
+        #            'bridge_node_name': 'test_robot_joint_state_bridge'
+        #        }.items()
+        #    )
+        #]),
+        #GroupAction(actions = [
+        #    IncludeLaunchDescription(
+        #        AnyLaunchDescriptionSource([
+        #            ThisLaunchFileDir(), '/test_robot.launch.py'
+        #        ]),
+        #        launch_arguments = {
+        #            # Launch arguments chain guard
+        #            'namespace': '',
+        #            'use_sim_time': use_sim_time,
+        #            'use_rviz': LaunchConfiguration('use_rviz')
+        #        }.items()
+        #    ),
+        #    IncludeLaunchDescription(
+        #        AnyLaunchDescriptionSource([
+        #            ThisLaunchFileDir(), '/ignition_bridge.launch.py'
+        #        ]),
+        #        launch_arguments = {
+        #            'with_stf': 'true',
+        #            'ign_frame_id': ['test_robot/upper_body_link/upper_imu'],
+        #            'ros_frame_id': 'upper_imu_link',
+        #            'ign_topic': [
+        #                '/world/', world_name, '/model/test_robot/link/upper_body_link/sensor/upper_imu/imu'
+        #            ],
+        #            'ros_topic': 'upper_imu/data_raw',
+        #            'convert_args': 'sensor_msgs/msg/Imu[ignition.msgs.IMU',
+        #        }.items()
+        #    ),
+        #    IncludeLaunchDescription(
+        #        AnyLaunchDescriptionSource([
+        #            ThisLaunchFileDir(), '/ignition_bridge.launch.py'
+        #        ]),
+        #        launch_arguments = {
+        #            'with_stf': 'true',
+        #            'ign_frame_id': ['test_robot/base_link/lower_imu'],
+        #            'ros_frame_id': 'lower_imu_link',
+        #            'ign_topic': [
+        #                '/world/', world_name, '/model/test_robot/link/base_link/sensor/lower_imu/imu'
+        #            ],
+        #            'ros_topic': 'lower_imu/data_raw',
+        #            'convert_args': 'sensor_msgs/msg/Imu[ignition.msgs.IMU',
+        #        }.items()
+        #    ),
+        #    IncludeLaunchDescription(
+        #        AnyLaunchDescriptionSource([
+        #            ThisLaunchFileDir(), '/ignition_bridge.launch.py'
+        #        ]),
+        #        launch_arguments = {
+        #            'with_stf': 'true',
+        #            'ign_frame_id': ['test_robot/upper_body_link/front_camera'],
+        #            'ros_frame_id': 'front_camera_link',
+        #            'ign_topic': [
+        #                '/world/', world_name, '/model/test_robot/link/upper_body_link/sensor/front_camera/camera_info'
+        #            ],
+        #            'ros_topic': 'front_camera/camera_info',
+        #            'convert_args': 'sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo'
+        #        }.items()
+        #    ),
+        #    IncludeLaunchDescription(
+        #        AnyLaunchDescriptionSource([
+        #            ThisLaunchFileDir(), '/ignition_image_bridge.launch.py'
+        #        ]),
+        #        launch_arguments = {
+        #            'with_stf': 'false',
+        #            'ign_topic': [
+        #                '/world/', world_name, '/model/test_robot/link/upper_body_link/sensor/front_camera/image'
+        #            ],
+        #            'ros_topic': 'front_camera/image'
+        #        }.items()
+        #    ),
+        #    IncludeLaunchDescription(
+        #        AnyLaunchDescriptionSource([
+        #            ThisLaunchFileDir(), '/ignition_image_bridge.launch.py'
+        #        ]),
+        #        launch_arguments = {
+        #            'with_stf': 'false',
+        #            'ign_topic': [
+        #                '/world/', world_name, '/model/test_robot/link/upper_body_link/sensor/front_camera/depth_image'
+        #            ],
+        #            'ros_topic': 'front_camera/depth_image'
+        #        }.items()
+        #    ),
+        #    IncludeLaunchDescription(
+        #        AnyLaunchDescriptionSource([
+        #            ThisLaunchFileDir(), '/ignition_bridge.launch.py'
+        #        ]),
+        #        launch_arguments = {
+        #            'with_stf': 'false',
+        #            'ign_topic': [
+        #                '/world/', world_name, '/model/test_robot/link/upper_body_link/sensor/front_camera/points'
+        #            ],
+        #            'ros_topic': 'front_camera/points',
+        #            'convert_args': 'sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked'
+        #        }.items()
+        #    )
+        #])
     ]
 
 if __name__ == '__main__':

--- a/launch/simulate_test_robot.launch.py
+++ b/launch/simulate_test_robot.launch.py
@@ -95,121 +95,19 @@ def generate_launch_nodes():
         ),
         IncludeLaunchDescription(
             AnyLaunchDescriptionSource([
-                ThisLaunchFileDir(), '/multiple_ignition_bridge.launch.py'
+                ThisLaunchFileDir(), '/test_robot.launch.py'
             ]),
+            launch_arguments = {
+                'namespace': '',  # Launch arguments chain guard
+                'use_sim_time': use_sim_time,
+                'use_rviz': LaunchConfiguration('use_rviz')
+            }.items()
+        ),
+        IncludeLaunchDescription(
+            AnyLaunchDescriptionSource([
+                ThisLaunchFileDir(), '/multiple_ignition_bridge.launch.py'
+            ])
         )
-        #GroupAction(actions = [
-        #    PushRosNamespace(
-        #        namespace = namespace
-        #    ),
-        #    IncludeLaunchDescription(
-        #        AnyLaunchDescriptionSource([
-        #            ThisLaunchFileDir(), '/ignition_bridge.launch.py'
-        #        ]),
-        #        launch_arguments = {
-        #            'with_stf': 'false',
-        #            'ign_topic': ['/world/', world_name, '/model/test_robot/joint_state'],
-        #            'ros_topic': 'joint_states',
-        #            'convert_args': 'sensor_msgs/msg/JointState[ignition.msgs.Model',
-        #            'bridge_node_name': 'test_robot_joint_state_bridge'
-        #        }.items()
-        #    )
-        #]),
-        #GroupAction(actions = [
-        #    IncludeLaunchDescription(
-        #        AnyLaunchDescriptionSource([
-        #            ThisLaunchFileDir(), '/test_robot.launch.py'
-        #        ]),
-        #        launch_arguments = {
-        #            # Launch arguments chain guard
-        #            'namespace': '',
-        #            'use_sim_time': use_sim_time,
-        #            'use_rviz': LaunchConfiguration('use_rviz')
-        #        }.items()
-        #    ),
-        #    IncludeLaunchDescription(
-        #        AnyLaunchDescriptionSource([
-        #            ThisLaunchFileDir(), '/ignition_bridge.launch.py'
-        #        ]),
-        #        launch_arguments = {
-        #            'with_stf': 'true',
-        #            'ign_frame_id': ['test_robot/upper_body_link/upper_imu'],
-        #            'ros_frame_id': 'upper_imu_link',
-        #            'ign_topic': [
-        #                '/world/', world_name, '/model/test_robot/link/upper_body_link/sensor/upper_imu/imu'
-        #            ],
-        #            'ros_topic': 'upper_imu/data_raw',
-        #            'convert_args': 'sensor_msgs/msg/Imu[ignition.msgs.IMU',
-        #        }.items()
-        #    ),
-        #    IncludeLaunchDescription(
-        #        AnyLaunchDescriptionSource([
-        #            ThisLaunchFileDir(), '/ignition_bridge.launch.py'
-        #        ]),
-        #        launch_arguments = {
-        #            'with_stf': 'true',
-        #            'ign_frame_id': ['test_robot/base_link/lower_imu'],
-        #            'ros_frame_id': 'lower_imu_link',
-        #            'ign_topic': [
-        #                '/world/', world_name, '/model/test_robot/link/base_link/sensor/lower_imu/imu'
-        #            ],
-        #            'ros_topic': 'lower_imu/data_raw',
-        #            'convert_args': 'sensor_msgs/msg/Imu[ignition.msgs.IMU',
-        #        }.items()
-        #    ),
-        #    IncludeLaunchDescription(
-        #        AnyLaunchDescriptionSource([
-        #            ThisLaunchFileDir(), '/ignition_bridge.launch.py'
-        #        ]),
-        #        launch_arguments = {
-        #            'with_stf': 'true',
-        #            'ign_frame_id': ['test_robot/upper_body_link/front_camera'],
-        #            'ros_frame_id': 'front_camera_link',
-        #            'ign_topic': [
-        #                '/world/', world_name, '/model/test_robot/link/upper_body_link/sensor/front_camera/camera_info'
-        #            ],
-        #            'ros_topic': 'front_camera/camera_info',
-        #            'convert_args': 'sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo'
-        #        }.items()
-        #    ),
-        #    IncludeLaunchDescription(
-        #        AnyLaunchDescriptionSource([
-        #            ThisLaunchFileDir(), '/ignition_image_bridge.launch.py'
-        #        ]),
-        #        launch_arguments = {
-        #            'with_stf': 'false',
-        #            'ign_topic': [
-        #                '/world/', world_name, '/model/test_robot/link/upper_body_link/sensor/front_camera/image'
-        #            ],
-        #            'ros_topic': 'front_camera/image'
-        #        }.items()
-        #    ),
-        #    IncludeLaunchDescription(
-        #        AnyLaunchDescriptionSource([
-        #            ThisLaunchFileDir(), '/ignition_image_bridge.launch.py'
-        #        ]),
-        #        launch_arguments = {
-        #            'with_stf': 'false',
-        #            'ign_topic': [
-        #                '/world/', world_name, '/model/test_robot/link/upper_body_link/sensor/front_camera/depth_image'
-        #            ],
-        #            'ros_topic': 'front_camera/depth_image'
-        #        }.items()
-        #    ),
-        #    IncludeLaunchDescription(
-        #        AnyLaunchDescriptionSource([
-        #            ThisLaunchFileDir(), '/ignition_bridge.launch.py'
-        #        ]),
-        #        launch_arguments = {
-        #            'with_stf': 'false',
-        #            'ign_topic': [
-        #                '/world/', world_name, '/model/test_robot/link/upper_body_link/sensor/front_camera/points'
-        #            ],
-        #            'ros_topic': 'front_camera/points',
-        #            'convert_args': 'sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked'
-        #        }.items()
-        #    )
-        #])
     ]
 
 if __name__ == '__main__':

--- a/models/urdf/camera_link_macro.xacro
+++ b/models/urdf/camera_link_macro.xacro
@@ -29,13 +29,13 @@
     </joint>
     <gazebo reference="${prefix}_camera_link">
       <sensor name="${prefix}_camera" type="rgbd_camera">
-        <update_rate>10</update_rate>
+        <update_rate>5</update_rate>
         <enable_metrics>true</enable_metrics>
         <camera>
           <horizontal_fov>1.9</horizontal_fov>
           <image>
-            <width>1280</width>
-            <height>720</height>
+            <width>128</width>
+            <height>72</height>
           </image>
           <depth_camera>
             <clip>

--- a/models/urdf/imu_link_macro.xacro
+++ b/models/urdf/imu_link_macro.xacro
@@ -17,7 +17,7 @@
     </joint>
     <gazebo reference="${prefix}_imu_link">
       <sensor name="${prefix}_imu" type="imu">
-        <update_rate>50</update_rate>
+        <update_rate>30</update_rate>
         <imu>
           <angular_velocity>
             <x>

--- a/rviz/test_robot.rviz
+++ b/rviz/test_robot.rviz
@@ -54,7 +54,17 @@ Visualization Manager:
         All Enabled: true
         base_link:
           Value: true
+        center_arm_link:
+          Value: true
+        center_lower_arm_link:
+          Value: true
+        center_upper_arm_link:
+          Value: true
         front_camera_link:
+          Value: true
+        front_caster_link:
+          Value: true
+        front_swivel_link:
           Value: true
         left_wheel_link:
           Value: true
@@ -72,7 +82,7 @@ Visualization Manager:
           Value: true
         test_robot/upper_body_link/front_camera:
           Value: true
-        test_robot/upper_body_link/upper_imu:
+        test_robot/upper_imu_link/upper_imu:
           Value: true
         upper_body_link:
           Value: true
@@ -86,6 +96,9 @@ Visualization Manager:
       Tree:
         base_link:
           lower_body_link:
+            front_swivel_link:
+              front_caster_link:
+                {}
             left_wheel_link:
               {}
             lower_imu_link:
@@ -97,11 +110,15 @@ Visualization Manager:
             right_wheel_link:
               {}
             upper_body_link:
+              center_arm_link:
+                center_lower_arm_link:
+                  center_upper_arm_link:
+                    {}
               front_camera_link:
                 test_robot/upper_body_link/front_camera:
                   {}
               upper_imu_link:
-                test_robot/upper_body_link/upper_imu:
+                test_robot/upper_imu_link/upper_imu:
                   {}
       Update Interval: 0
       Value: true
@@ -127,7 +144,32 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
+        center_arm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        center_lower_arm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        center_upper_arm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
         front_camera_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_caster_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_swivel_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -252,7 +294,7 @@ Visualization Manager:
       Name: Depth Points
       Position Transformer: XYZ
       Selectable: true
-      Size (Pixels): 1
+      Size (Pixels): 5
       Size (m): 0.009999999776482582
       Style: Points
       Topic:


### PR DESCRIPTION
From the standpoint of computational resources, it is better to use multiple nodes than to use a single `parameter_bridge`.
In addition, `parameter_bridge` is characterized by long and complex arguments.

To solve these problems, we have created `multiple_ignition_bridge.launch.py`, which can be configured to launch from a configuration file.

However, we have not checked if it is recommended to launch the startup file in this way, so we may change to the recommended method in the future.